### PR TITLE
Update readme to include missing setup step for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Once Ruby, Jekyll, and Git are setup:
 
     git clone https://github.com/gutenbergtools/gutenbergsite.git
     cd gutenbergsite
+    bundle install
     bundle exec jekyll serve
 
 Then open your web browser to http://localhost:4000


### PR DESCRIPTION
The dev instructions as written are missing a step (`bundle install`).