### PR TITLE
Revert "Take out deprecated/unnecessary UX part on browse-by pages"

### DIFF
--- a/catalog/admin/make-by-pages.php
+++ b/catalog/admin/make-by-pages.php
@@ -96,9 +96,15 @@ function _navbarcategories ($what, $dir) {
     
 function navbar () {
   global $dir_authors, $dir_titles, $dir_langs, $dir_loccs, $dir_categories, $dir_recent, $lang_thres;
-  $nav = "<div class=\"pgdbnavbar\">\n";
-  $nav .= _navbarrecent ("Recent", $dir_recent);
-  $nav .= "</div>\n\n";
+  $nav  = "<div class=\"pgdbnavbar\">\n";
+  $nav .= _navbar       ("Authors",   $dir_authors);
+  $nav .= _navbar       ("Titles",    $dir_titles);
+  $nav .= _navbarlangs  ("Languages with more than $lang_thres books", "> $lang_thres", $dir_langs);
+  $nav .= _navbarlangs  ("Languages with up to $lang_thres books", "<= $lang_thres", $dir_langs);
+  //  $nav .= _navbarloccs  ("LoC Class", $dir_loccs);
+  $nav .= _navbarcategories ("Special Categories", $dir_categories);
+  $nav .= _navbarrecent     ("Recent",     $dir_recent);
+  $nav .= "</div>\n\n"; 
   return $nav;
 }
     


### PR DESCRIPTION
#142 is on dev, and I think we need to go back to the drawing board.
compare https://gutenberg.org/browse/languages/fr and https://dev.gutenberg.org/browse/languages/fr

besides the lack of a title #149 on all the browse pages, ALL of the links to "browse pages" in the current version would suddenly be absent from the entire website. We need a coherent organization of all the browse pages. 

Perhaps borrow from the "search options" page and present a "browse options" page.

This PR reverts gutenbergtools/gutenbergsite#142. will merge when we have an alternative to review.