### PR TITLE
Update style2.css

### DIFF
--- a/gutenberg/style2.css
+++ b/gutenberg/style2.css
@@ -253,7 +253,7 @@ ul {
 
 @media (min-width: 1024px) {
   h1, h2, h3, h4, h5, h6 {
-    scroll-margin-top: 60px; /* keeps headings out from under fixed header */
+    scroll-margin-top: calc(60px + 0.5rem); /* keeps headings out from under fixed header */
   }
 }
 


### PR DESCRIPTION
Fix for header sometimes covering too much text in case of internal links to ids. issue brought up on slack.

I've tested locally on two particular cases and it works for them. More testing on dev required.