### PR TITLE
Proper scope enforced for universal selector

### DIFF
--- a/gutenberg/new_nav.css
+++ b/gutenberg/new_nav.css
@@ -1,4 +1,4 @@
-* {
+header * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;


### PR DESCRIPTION
Global restyling shouldn't be in a CSS file that's labeled for just the navigation.