### PR TITLE
New Newsletter for January 2026

### DIFF
--- a/site/newsletter/index.md
+++ b/site/newsletter/index.md
@@ -6,106 +6,198 @@ permalink: /newsletter/
 
 # Project Gutenberg News
 
-### December 2025
+### January 2026
 
 ___—Enjoy these eBooks. Share them. Celebrate them.—___
 
 
 **Contents**
 
-* Illustration of Greg Newby and Michael Hart
-* In the News about eBooks for November 2025
+* Note from the new Executive Director
+* Milestones for 2025
+* Report of PG’s Social Media Activity for 2025
+* Happy Public Domain Day 2026
+* More eBooks Released
 * Legal News: eBook Lending and Copyright
-* Reflecting on Public Domain Day 2025
-* Top 100 eBooks downloaded for the month of November
-* PG AI Audiobooks Coming Soon!
+* The Digital Renaissance of the Public Domain
+* PG AI Large Scale Audiobook Synthesis Using LLMS and Text-To-Speech
+* Top 10 eBooks downloaded for the month of December 2025
 * Project Gutenberg Self Publishing Portal
-* Recent PG Releases
 * Join Distributed Proofreaders
-* Find Project Gutenberg on social media
+* Selected New Releases at Gutenberg.org — December 2025
+* Find Project Gutenberg on Social Media
 
 
-## Celebrating Greg Newby in Illustration
+## Note from the New Executive Director
 
-On behalf of all of us at PGLAF, we sincerely appreciate the illustrated likeness of Michael Hart and Gregory Newby. Note about the illustration, illustrator Denis Renard, and publication by Marie Lebert.
-> <https://marielebert.wordpress.com/2022/10/07/denis-renard/>
+Happy Public Domain Day!
+
+People may state that books published in 1930 have "fallen" into the US Public Domain, or that they have lost copyright "protection". This is not quite correct. Rather, books published in 1930 have been FREED of copyright restrictions. They have ASCENDED into the public domain and into the embrace of organizations like Project Gutenberg. They now belong to ALL of us, and we need to take care of them for future generations.
+
+On October 21, Project Gutenberg lost its longtime leader, Greg Newby, to pancreatic cancer. I agreed to step up as Acting Executive Director so that Project Gutenberg could continue the mission that had become Greg's life work: to serve and preserve public domain books so all of us can use and enjoy them without restrictions.
+
+Although I've been doing development work for Project Gutenberg for the past 8 years, I did not really understand what Greg's job entailed, or how many tasks he had been juggling. Three months in, I'm still discovering mysterious-to-me aspects of the organization.
+
+In the past three months Project Gutenberg has proven to be resilient; we took a heavy blow and managed to keep going. I've been amazed at the dedication and talent of the many volunteers behind Project Gutenberg and our sister organization, Distributed Proofreaders. And at the large number of donors who make the organization financially viable and sustainable. So as of 2026, with your support, I'm continuing as Executive Director.
+
+— Eric Hellman, Executive Director, Project Gutenberg and PGLAF
 
 
-## In the news about eBooks for November 2025
+## Milestones for 2025
 
-Key eBook news items and trends as November 2025 include:
+Monthly Contributions: Volunteers maintained a steady output. In 2025, Project Gutenberg added over 2,000 new eBooks, consistent with its typical rate of 30 to 50 new items added weekly.
 
-AI and Copyright Lawsuits: There is news about publisher OverDrive suing OpenAI over AI training data and related copyright issues, a significant development for authors concerned about intellectual property rights.
+Self-Publishing Success: The Project Gutenberg Self-Publishing Portal, an author-led community, saw steady activity with over 100 new titles submitted monthly by contemporary authors looking to share their work freely.
 
-Audiobook Growth: The rise in consumer demand for audiobooks means entrepreneurial authors and publishers are embracing an "audio-first" trend, seeking to leverage advances against audio rights while potentially self-publishing eBooks separately.
+MARC Records Restored: Library metadata records (MARC) became fully available again in 2025, aiding academic libraries in integrating Project Gutenberg titles into their own systems.
 
-Spotify has expanded audiobook access for Premium subscribers in five additional European countries.
+In July 2025, Project Gutenberg announced the addition of new high-speed mirror sites hosted by Old Dominion University (ODU) in Norfolk, Virginia. Maintained by the ODU Computer Science Systems Group, these mirrors enhance global redundancy for the collection.
+
+Intelligent Discovery: In collaboration with Empathy.ai, Project Gutenberg introduced AI-driven book summaries and browsing categories were added to book landing pages to help readers discover new works.
+
+AI Book Interaction: Project Gutenberg partnered with Empathy.ai to launch experimental models allowing users to chat with an AI about books and search the catalog using natural language.
+
+In honor of Greg, we added a special dedication to him on our home page starting in October, along with a supporting page and we supported the creation of a page at Wikipedia.
+
+> <https://www.gutenberg.org/about/newby.html>   
+> <https://en.wikipedia.org/wiki/Gregory_B._Newby>
+
+
+## Report of PG’s Social media activity in 2025
+
+The Facebook page has about 101,000 followers and received over 1 million views in the past year, with 18,000 reactions. The audience is primarily US-based (53%), evenly split between male and female, mostly aged 35-54. The most-viewed post, regarding Greg's passing, had 86,000 views. Follower growth was at 1% year-over-year.
+
+On Mastodon we have 28,012 new followers (total of 63,126 followers so far), 1,752 new posts and the most popular post (*Happy Public Domain Day*) was boosted 549 times. We also reached the top #64 of the most followed Mastodon accounts.
+
+On Bluesky we have 5,800 followers since this account was created, 2,100 posts and the most popular post this year (*The Mathilda Effect — The Missing Heroines of Science*) was boosted 516 times.
+
+A new account was created at Reddit (u/ProjectGutenberg) to support the r/projectgutenberg subreddit.
+
+## Happy Public Domain Day 2026
+
+In December the eBook community geared up for Public Domain Day on January 1, 2026, when thousands of works published in 1930 (plus sound recordings from 1925) enter the U.S. public domain. This means unrestricted access for remixing, adapting, and distributing—including free eBook editions. Many famous books and characters from 1930 will enter the U.S. public domain. This also means they can be legally digitized and shared by Project Gutenberg without copyright restrictions. Digital libraries and projects have been previewing releases.
+
+### Classic Literature and Thrillers
+
+* *The Maltese Falcon* by Dashiell Hammett: This novel introduced the world to the famous detective Sam Spade.
+* *As I Lay Dying* by William Faulkner: A masterpiece of American literature.
+* *The Murder at the Vicarage* by Agatha Christie: This was the first novel to feature the beloved character Miss Marple.
+* *Not Without Laughter* by Langston Hughes: The first novel published by this famous poet and leader of the Harlem Renaissance.
+* *Cakes and Ale* by W. Somerset Maugham: A popular social satire of the London literary world.
+* *The Castle* by Franz Kafka: The first English translation of this famous existentialist work.
+* *Twenty Years at Hull-House* by Jane Addams: The first American woman to be awarded the Nobel Peace Prize in 1931.
+
+### Children’s Books and Young Adult Classics
+
+* The **Nancy Drew** Series: The first four books, Including *The Secret of the Old Clock*, *The Hidden Staircase*, *The Bungalow Mystery*, and *The Mystery at Lilac Inn* by Carolyn Keene, will enter the public domain.
+* *The Little Engine That Could* by Watty Piper: The famous 1930 version of the story with illustrations by Lois Lenski.
+* *Swallows and Amazons* by Arthur Ransome: The first book in the classic series about children having adventures in the English Lake District.
+* *The Tale of Little Pig Robinson* by Beatrix Potter: One of the final books published in her famous animal series.
+* *The Cat Who Went to Heaven* by Elizabeth Coatsworth: It won the Newbery Medal for excellence in American children's literature in 1931.
+
+### Poetry and Plays
+
+* *Ash Wednesday* by T.S. Eliot: A major long-form poem.
+* *Private Lives* by Noël Coward: A famous and witty comedy play.
+* *The Bridge* by Hart Crane: A famous modernist epic poem.
+
+### Famous Characters & Icons
+
+* **Mickey Mouse Comics**: The very first daily comic strips featuring Mickey Mouse from 1930 will become free to use.
+* **Betty Boop**: Her first cartoon appearance in the short film *Dizzy Dishes* becomes public domain.
+* **Pluto**: Mickey’s dog (first named Rover) made his debut in 1930.
+* **Blondie**: The famous comic strip featuring Blondie and Dagwood first appeared in September 1930.
+
+## More eBooks released
+
+**Internet Archive's Free Digital Library Expansion:** The Internet Archive is set to unlock free eBook downloads of over 100,000 scanned 1930 volumes starting January 1, 2026, alongside audio and video remixes. In a December 1 announcement, they launched the Public Domain Film Remix Contest, inviting creators to produce short films from 1930-era public domain works (entries due March 2026). eBook access emphasizes searchable PDFs and EPUB conversions for titles like The Maltese Falcon.
+
+> <https://blog.archive.org/2025/12/01/>
+
+**HathiTrust Adds 78,000+ Digital Items:** In a December 16, 2025 post, HathiTrust revealed plans to release over 78,000 digitized 1930 books into full public view, including high-res scans convertible to eBooks via their tools. A dedicated 1930 Publications Collection goes live January 1, with global access to 57,000 additional titles from Canada/Australia (1899–1900). Users can download EPUBs or read online; some previews are already available through their Copyright Review Program.
+
+> <https://www.hathitrust.org/press-post/coming-in-january-public-domain-day-2026/>
+
+**Duke University’s Center for the Study of the Public Domain:** The annual roundup notes no major legal hurdles this year, boosting indie eBook creators. Articles from December 7 and 20 highlight remix potential, like “podifying” Nancy Drew or AI-narrating As I Lay Dying. Expect a surge in platforms like Project Gutenberg adding these titles by mid-January. These releases democratize access, especially for Project Gutenberg e-readers.
+
+> <https://web.law.duke.edu/cspd/publicdomainday/2026/>
+
 
 ## Legal News: eBook Lending and Copyright
 
-A significant legal development in late 2024 involved the Internet Archive's legal battle over its digital lending practices. The organization decided not to appeal a U.S. Court of Appeals ruling that found its "controlled digital lending" (CDL) model, which involved lending scanned digital copies of physical books, was not a "fair use" under copyright law. The case, Hachette Book Group, Inc. v. Internet Archive, was a closely watched dispute involving major publishers and had a significant impact on how libraries approach digital lending of copyrighted materials.
+**Hachette vs The Internet Archive**: The primary legal news revolves around the long-running lawsuit Hachette Book Group, Inc. v. The Internet Archive, which challenged the practice of Controlled Digital Lending (CDL). CDL allows libraries to digitize physical books they own and lend digital versions on a one-to-one basis (one digital loan per physical copy owned), mimicking traditional library lending.
 
-AI and Copyright Tensions: Mid-November saw heated debates on X about AI training data, with authors accusing OpenAI of scraping books (including public domain ones) without consent. A related lawsuit gained traction, potentially affecting how AI models handle free eBooks.
+In March 2023, a U.S. District Court ruled against the Internet Archive, finding CDL did not qualify as fair use. In December 2024, the Internet Archive announced it would not pursue further appeals (e.g., to the Supreme Court), effectively ending the case.
 
-November's X conversations about PG had some trending, with users recommending Gutenberg for classics like Dracula and Meditations. A viral thread noted how public domain status means "no fees, no licenses," sparking eBook recommendation lists.
+This is a setback for open digital access advocates: CDL was promoted as extending traditional library lending to the digital age. The loss weakens alternatives to publisher-controlled licensing, limiting options for free/unrestricted digital access (especially for older or niche titles).
 
-> Dracula by Bram Stoker  
-  <https://www.gutenberg.org/ebooks/345>
+> <https://en.wikipedia.org/wiki/Hachette_v._Internet_Archive>
 
-> Meditations by Emperor of Rome Marcus Aurelius  
-  <https://www.gutenberg.org/ebooks/2680>
+**Amazon to begin selling DRM-free eBooks**: In December 2025, Amazon announced changes allowing DRM-free self-published eBooks in open formats (EPUB/PDF) starting January 2026, potentially easing some lending/friction issues for indie authors.
 
-## Reflecting on Public Domain Day 2025
+> <https://kdp.amazon.com/en_US/help/topic/GDDXGH9VR22ACM8U>
 
-Last year, in November 2024, the primary focus in public domain eBooks news was centered on the impending Public Domain Day on January 1, 2025, when thousands of works from 1929 (plus 1924 sound recordings) entered into the U.S. public domain. This event has always generated significant buzz among digital libraries, authors, and readers, with platforms like Project Gutenberg and Standard eBooks preparing free eBook releases. Discussions emphasized how these additions will enrich free digital collections, allowing unrestricted sharing, adaptation, and remixing of classics. Here's a breakdown of the Major Works Entering the Public Domain 11 months ago:
+**Anti-ownership in the eBook economy:** Scholarly articles and reports in 2025 highlight the "anti-ownership" eBook economy and calls for fairer library terms. This case represents a major victory for publishers' rights but a setback for open digital access advocates. Libraries may increasingly rely on licensed platforms like OverDrive/Libby for eBook lending.
 
-These titles, now free for eBooks distribution and adaptation, include literary heavyweights from the late 1920s. Highlights featured last November:
+The "anti-ownership" eBook economy refers to the current system in the digital book market where consumers and institutions (like libraries) typically do not truly own eBooks they "purchase." Instead, they acquire limited licenses to access them. This contrasts sharply with physical books, where buyers gain full ownership rights, including the ability to resell, lend freely, donate, or read without tracking under doctrines like the First Sale Doctrine in copyright law.
 
-* Ernest Hemingway’s, A Farewell to Arms  
-  Iconic war novel; expected to see new eBooks editions and adaptations.  
-  <https://www.gutenberg.org/ebooks/75201>
+Organizations like IFLA (International Federation of Library Associations), ReadersFirst, and #eBookSOS campaign advocates for principles like respecting copyright exceptions in licenses, allowing preservation/reformatting, and enabling interlibrary loans.
 
-* Virginia Woolf’s, A Room of One's Own  
-  Feminist essay; poised for fresh digital annotations and audiobooks.  
-  <https://gutenberg.net.au/ebooks02/0200791h.html>  
-  — From Project Gutenberg Australia!
+Proposed Legislation: Proposals for state-level mandates on reasonable terms, or federal updates to exceptions for libraries/archives (e.g., Section 108 of the Copyright Act).
 
-* William Faulkner’s, The Sound and the Fury  
-  Modernist masterpiece; highlights the "Roaring '20s" cultural wave entering free access.  
-  <https://www.gutenberg.org/ebooks/75170>
-
-* Agatha Christie’s The Seven Dials Mystery  
-  Early detective story; boosts mystery genre.  
-  <https://www.gutenberg.org/ebooks/75288>
-
-* Dashiell Hammett’s, The Maltese Falcon (serialized version)  
-  Hardboiled noir classic; anticipated for graphic novel and eBook remixes.  
-  <https://gutenberg.ca/ebooks/hammettd-maltesefalcon/hammettd-maltesefalcon-00-h.html>  
-  — From Project Gutenberg Canada!
-
-Other notables include All Quiet on the Western Front by Erich Maria Remarque and early Tintin comics by Hergé. Also sound recordings like George Gershwin's Rhapsody in Blue.
-
-_Next month, we will have a list of works newly available in 2026._
-
-## Top 10 eBooks downloaded for the month of November 2025
-
-1. Frankenstein; Or, The Modern Prometheus by Mary Wollstonecraft Shelley (303,221)
-1. Moby Dick; Or, The Whale by Herman Melville (119,658)
-1. Pride and Prejudice by Jane Austen (85,862)
-1. The King in Yellow by Robert W. Chambers (76,744)
-1. Romeo and Juliet by William Shakespeare (73,678)
-1. The Strange Case of Dr. Jekyll and Mr. Hyde by Robert Louis Stevenson (65,938)
-1. Alice's Adventures in Wonderland by Lewis Carroll (63,702)
-1. The Complete Works of William Shakespeare by William Shakespeare (57,775)
-1. Middlemarch by George Eliot (53,818)
-1. A Room with a View by E. M. Forster (53,757)
+> <https://www.authorsalliance.org/2025/06/30/>
 
 
-## PG AI Audiobooks coming soon!
+## The Digital Renaissance of the Public Domain
 
-The next-generation of PG audiobooks is coming soon. There will likely be two audiobooks per book (one male and one female). Feedback and demand have been positive. We are looking forward to continuing this collaboration. 
+The landscape of digital literature has reached a pivotal milestone this year. As we celebrate the dawn of 2026, the arrival of "Public Domain Day" has once again sparked a surge of interest in the platforms that preserve and polish our shared cultural heritage. While the publishing industry often focuses on the latest bestsellers, a dedicated ecosystem of volunteer-driven projects is ensuring that the "Great Conversation" of human history is more accessible, and more beautiful, than ever before.
 
-The team of talented, and bright collaborators, have recently made some great progress on a v2 version of the open audiobook collection. They have been working on for the past few months to expand the collection to all 70K books, through the use of LLMs to automatically determine what should be read aloud and what should not be. Unlike the previous effort, which involved a lot of manual cleaning effort, this new effort will automate that with a series of LLM prompts so that we can automatically read things more like a human would. The AI audiobooks use some newer speech models to generate recordings, and tackle the issue of male and female voices.
+#### The Academic Powerhouse: HathiTrust
+
+A massive scholarly weight to the digital library landscape is HathiTrust <https://hathitrust.org>. Founded as a non-profit collaborative of academic and research libraries, it now preserves over 19 million digitized items. For Public Domain Day 2026, HathiTrust is opening access to more than 78,000 items published in 1930. Unlike casual repositories, HathiTrust serves a dual mission of preservation and advanced research, offering specialized services like the Accessible Text Request Service for users with print disabilities and tools for large-scale data analysis. It stands as a critical bridge between the world’s research libraries and the public.
+
+#### The New Standards of Quality
+
+Leading the charge in digital aesthetics is Standard eBooks <https://standardebooks.org>. This project treats the public domain with the reverence of a high-end boutique. On Public Domain Day 2026, the site added 20 new titles from 1930 to its catalog, each featuring professional typography, "curly" quotes, and custom covers sourced from period-appropriate fine art.
+
+"Standard Ebooks isn't just about hosting files; it's about creating editions that people actually want to read on modern devices," says the project’s mission statement. By focusing on "libre" and DRM-free content, they provide a high-fidelity alternative for ereader enthusiasts who refuse to compromise on design.
+
+#### A Voice for the Classics
+
+While Standard Ebooks masters the visual, LibriVox <https://libravox.org> continues to dominate the auditory realm. As of late 2024, the volunteer-driven powerhouse surpassed 20,000 free audiobooks. The project’s strength lies in its sheer human scale; thousands of volunteers worldwide record everything from Shakespeare to Austen in over 49 languages. For students, the visually impaired, and the growing "commuter class" of listeners, LibriVox remains the premier ad-free archive of the human voice.
+
+#### Bridging the Accessibility Gap
+
+Navigating the vast sea of public domain content is made easier by platforms like Loyal Books <https://loyalbooks.com> and ManyBooks <https://manybooks.net>. Loyal Books (formerly Books Should Be Free) has become a household name for families and casual readers. By hosting over 7,000 titles and offering both streaming audio and downloadable eBooks in one place, they simplify the user experience. Their mobile app has successfully brought the classics into the "on-the-go" lifestyle of the 2020s.
+
+Meanwhile, ManyBooks has grown into a massive digital library of over 50,000 titles. It serves as a unique hybrid in the literary world, sitting at the intersection of the past and the future. While it offers an exhaustive collection of classics across every imaginable genre, from sci-fi to philosophy, it also provides a platform for modern self-publishing authors. This creates a living continuum where the giants of literature share digital shelf space with the voices of tomorrow.
+
+#### A Shared Cultural Heritage
+
+Together, Project Gutenberg, Internet Archive, Hathi Trust, Standard eBooks, LibriVox, Loyal Books, and ManyBooks, provide a robust infrastructure for the preservation of thought. In an era where digital subscriptions and "rented" content have become the norm, these projects stand as a reminder that the world’s greatest stories belong to everyone. As 2025 comes to an end, and we move deeper into the 21st century, the wisdom of the 19th and 20th remains just a click, or a play button, away.
+
+— By John Guagliardo, PG Newsletter Staff, January 1, 2026
+
+
+## PG AI Large Scale Audiobook Synthesis Using LLMS and Text-To-Speech
+
+Project Gutenberg, joins a groundbreaking collaboration with MIT's Computer Science and Artificial Intelligence Laboratory (CSAIL), Department of Electrical and Computer Engineering at the University of Rochester, and Microsoft. The goal was to dramatically expand access to literature by automatically converting thousands of text-based e-books into high-quality audiobooks using AI-driven technologies. This isn't just about technology—it's about discovery. These audiobooks empower visually impaired readers, language learners, busy parents sharing stories with children, and anyone craving the magic of oral tradition on the go. Closing a massive gap: before, only a sliver of our 76,000+ e-books had audio versions.
+
+Stay tuned for the AI Audiobook launch coming soon!
+
+
+## Top 10 eBooks downloaded for December 2025
+
+1. *Frankenstein*, Mary Wollstonecraft Shelley - <https://www.gutenberg.org/ebooks/84>
+1. *Moby Dick*, Herman Melville - <https://www.gutenberg.org/ebooks/2701>
+1. *A Christmas Carol in Prose*, Charles Dickens - <https://www.gutenberg.org/ebooks/46>
+1. *Pride and Prejudice*, Jane Austen - <https://www.gutenberg.org/ebooks/1342>
+1. *Romeo and Juliet*, William Shakespeare - <https://www.gutenberg.org/ebooks/1513>
+1. *Dr. Jekyll and Mr. Hyde*, Robert Louis Stevenson - <https://www.gutenberg.org/ebooks/43>
+1. *The Complete Works of William Shakespeare* - <https://www.gutenberg.org/ebooks/100>
+1. *Alice's Adventures in Wonderland*, Lewis Carroll - <https://www.gutenberg.org/ebooks/11>
+1. *Twas the Night before Christmas*, Clement Clarke Moore - <https://www.gutenberg.org/ebooks/17135>
+1. *Middlemarch*, George Eliot - <https://www.gutenberg.org/ebooks/145>
 
 
 ## Project Gutenberg Self Publishing Portal
@@ -114,14 +206,21 @@ The team of talented, and bright collaborators, have recently made some great pr
 
 Project Gutenberg has focused mostly on the re-creation of paper books rather than the distribution of new authors and material, and we have spent as much of our time on finding books and doing copyright research as on eBook creation and distribution. Project Gutenberg Self Publishing Portal focuses solely on distribution rather than creation.
 
-In 2011 Michael Hart and John Guagliardo created the Project Gutenberg Self Publishing Portal and Author’s Community, <https://self.gutenberg.org>.  Since then we have published over 20,000 titles.  For the month of November there were 107 titles submitted and 73 approved, <https://self.gutenberg.org/RecentPublications>.
+In 2011 Michael Hart and John Guagliardo created the Project Gutenberg Self Publishing Portal and Author’s Community, <https://self.gutenberg.org>. Since then we have published over 20,000 titles. For the month of November there were 107 titles submitted and 73 approved, <https://self.gutenberg.org/RecentPublications>.
 
 If you or anyone you know, ever wished to have their title published at Project Gutenberg, visit <https://self.gutenberg.org> and join the author’s community. It is also a great place to find thousands of contemporary self-published titles.
 
 
-## Selected New Releases at Gutenberg.org - November 2025
+## Join Distributed Proofreaders
 
-In the last month PGLAF added another **211** new public domain eBooks to the PG catalog. Of the new books, 136 were added by PGDP. Thank you to all the volunteers who have helped to make these new titles freely available to the world.
+Visit [Distributed Proofreaders](https://pgdp.net) to learn how to create eBooks for Project Gutenberg. Proofreading a page a day is easy, fun, and a great way to help bring literature to the digital world. There are a variety of roles for the different steps involved in digitizing a printed book to make a Project Gutenberg eBook. Beginners are welcome, and there is an online tutorial to get started.
+
+> <https://pgdp.net>
+
+
+## Selected New Releases at Gutenberg.org — December 2025
+
+In the last month PGLAF added another **219** new public domain eBooks to the PG catalog. Of the new books, 131 were added by PGDP. Thank you to all the volunteers who have helped to make these new titles freely available to the world.
 
 These eBooks are now available at:
 
@@ -129,163 +228,112 @@ These eBooks are now available at:
 
 A selection of this month’s notable titles:
 
-Flaxius: Leaves from the Life of an Immortal,    
-Leland, Charles Godfrey (English)    
-334 pages; December 1, 2025    
-PG #77376 <https://www.gutenberg.org/ebooks/77376>
+The Lass of the Silver Sword  
+Du Bois, Mary Constance (English)  
+391 pages; Wednesday, December 31, 2025  
+PG #77584 <https://www.gutenberg.org/ebooks/77584>  
 
-The brave little maid of Goldau (1892),  
-Mary Elizabeth Jennings (English)  
-47 pages; December 1, 2025  
-PG #77374 <https://www.gutenberg.org/ebooks/77374>
+The scorpion, Weirauch,  
+Anna Elisabet (English)  
+284 pages; Wednesday, December 31, 2025  
+PG #77582 <https://www.gutenberg.org/ebooks/77582>  
 
-Brake Up; or, The Young Peacemakers,  
-Optic, Oliver (English)  
-318 pages; December 1, 2025  
-PG #77372 <https://www.gutenberg.org/ebooks/77372>
+Lost in the land of ice; or, Daring adventures around the South Pole,  
+Bonehill, Ralph (English)  
+251 pages; Wednesday, December 31, 2025  
+PG #77580 <https://www.gutenberg.org/ebooks/77580>  
 
-Hold 'Em, Wyndham!, Barbour,  
-Ralph Henry (English)  
-285 pages; December 1, 2025  
-PG #77370 <https://www.gutenberg.org/ebooks/77370>
+The youth of Madame de Longueville: Or, New Revelations of Court and Convent in the Seventeenth Century, Cousin, Victor (English with French)  
+403 pages; Wednesday, December 31, 2025  
+PG #77579 <https://www.gutenberg.org/ebooks/77579>  
 
-Skum [1922],  
-Øberg, Edith (Norwegian)  
-137 pages; December 1, 2025  
-PG #77368 <https://www.gutenberg.org/ebooks/77368>
+The Writings of the Apostolic Fathers  
+Roberts, Alexander and Donaldson, James and Crombie, Frederic (English)  
+526 pages; Wednesday, December 31, 2025  
+PG #77576 <https://www.gutenberg.org/ebooks/77576>  
 
-Among the Isles of Shoals, Thaxter, Celia (English)  
-193 pages; November 29, 2025  
-PG #77366 <https://www.gutenberg.org/ebooks/77366>
+The Indiscretions of a Lady's Maid,  
+Le Queux, William (English with French)  
+320 pages; Wednesday, December 31, 2025  
+PG #77575 <https://www.gutenberg.org/ebooks/77575>  
 
-Bound to get there; or, A boy who could not be downed,  
-Franklin, Roy (English)  
-324 pages; November 29, 2025  
-PG #77365 <https://www.gutenberg.org/ebooks/77365>
+Il curato d'Orobio  
+Giovanni Visconti Venosta (Italian)  
+367 pages; Wednesday, December 31, 2025  
+PG #77574 <https://www.gutenberg.org/ebooks/77574>  
 
-Les conversations d'Émilie,  
-Épinay, Louise d' (French)  
-208 pages; November 29, 2025  
-PG #77364 <https://www.gutenberg.org/ebooks/77364>
+Lord Lister 0039: De Krankzinnige van Hanwell  
+Kurt Matull en Theo Blakensee (Dutch)  
+34 pages; Wednesday, December 31, 2025  
+PG #77573 <https://www.gutenberg.org/ebooks/77573>  
 
-Genesis (1910), A Critical and Exegetical Commentary on,  
-Skinner, John, 1851-1925. (English)  
-671 pages; November 29, 2025  
-PG #77363 <https://www.gutenberg.org/ebooks/77363>
+Nova Scotia, the province that has been passed by,  
+Willson, Beckles (English)  
+336 pages; Wednesday, December 31, 2025  
+PG #77572 <https://www.gutenberg.org/ebooks/77572>  
 
-Adrift on the Amazon,  
-Miller, Leo (English)  
-286 pages; November 28, 2025  
-PG #77361 <https://www.gutenberg.org/ebooks/77361>
+I tolfte timmen  
+Molander, Molly (Pseud. f. Almqvist, Gertrud) (Swedish)  
+174 pages; Wednesday, December 31, 2025  
+PG #77571 <https://www.gutenberg.org/ebooks/77571>  
 
-American medicinal barks,  
-Henkel, Alice (English)  
-61 pages; November 28, 2025  
-PG #77360 <https://www.gutenberg.org/ebooks/77360>
+Women in the shadows,  
+Bannon, Ann (English)  
+180 pages; Wednesday, December 31, 2025  
+PG #77570 <https://www.gutenberg.org/ebooks/77570>  
 
-Letters of John Huss, written during his exile and imprisonment,  
-Bonnechose, Émile de (English)  
-248 pages; November 28, 2025  
-PG #77359 <https://www.gutenberg.org/ebooks/77359>
+List of Post Offices in Canada 1870,  
+Postmaster General - Canadian Post Office (English)  
+139 pages; Wednesday, December 31, 2025  
+PG #77567 <https://www.gutenberg.org/ebooks/77567>  
 
-A lady's cruise in a French man-of-war [1882],  
-Gordon-Cumming, Constance Frederica (English)  
-397 pages; November 28, 2025  
-PG #77356 <https://www.gutenberg.org/ebooks/77356>
+Caoidh airson cor na Gaidhealtachd agus fogradh nan Gaidheal  
+Stewart, Duncan (Scottish Gaelic with English)  
+4 pages; Wednesday, December 31, 2025  
+PG #77566 <https://www.gutenberg.org/ebooks/77566>  
 
-Household words, no. 330, July 19, 1856: A weekly journal,  
-Dickens, Charles (editor) (English)  
-48 pages; November 28, 2025  
-PG #77354 <https://www.gutenberg.org/ebooks/77354>
+The caliph's design: Architects! Where is your vortex?  
+ Lewis, Wyndham (English with French)  
+72 pages; Wednesday, December 31, 2025  
+PG #77565 <https://www.gutenberg.org/ebooks/77565>  
 
-Historia de la instrucción pública en Puerto Rico hasta el año de 1898,  
-Coll y Toste, Cayetano (Spanish)  
-212 pages; November 28, 2025  
-PG #77353 <https://www.gutenberg.org/ebooks/77353>
+Facing old age,  
+Epstein, Abraham (English)  
+370 pages; Wednesday, December 31, 2025  
+PG #77562 <https://www.gutenberg.org/ebooks/77562>  
 
-Ten years in a Portsmouth slum,  
-Dolling, Robert R. (English)  
-318 pages; November 28, 2025  
-PG #77351 <https://www.gutenberg.org/ebooks/77351>
+A los pies de Venus,  
+Blasco Ibáñez, Vicente (Spanish)  
+337 pages; Tuesday, December 30, 2025  
+PG #77561 <https://www.gutenberg.org/ebooks/77561>  
 
-Bacchus; or, Wine To-day and To-morrow,  
-Shand, P. Morton (English with French)  
-96 pages; November 27, 2025  
-PG #77340 <https://www.gutenberg.org/ebooks/77340>
+The anatomy of the frog,  
+Ecker, Alexander (English)  
+471 pages; Tuesday, December 30, 2025  
+PG #77560 <https://www.gutenberg.org/ebooks/77560>  
 
-The English works of Thomas Hobbes of Malmesbury, vol 6 of 11,  
-Hobbes, Thomas (English)  
-540 pages; November 26, 2025  
-PG #77338 <https://www.gutenberg.org/ebooks/77338>
+The story of the Great Lakes,  
+Channing, Edward (English)  
+442 pages; Tuesday, December 30, 2025  
+PG #77559 <https://www.gutenberg.org/ebooks/77559>  
 
-Leben und Taten des scharfsinnigen Edlen  
-Don Quijote von la Mancha 1 {Fraktur}, Miguel de Cervantes Saavedra (Übers.: Tieck) (German)  
-379 pages; November 26, 2025  
-PG #77337 <https://www.gutenberg.org/ebooks/77337>
+Black America: A Study of the Ex-Slave and His Late Master,  
+Clowes, William Laird (English)  
+264 pages; Tuesday, December 30, 2025  
+PG #77558 <https://www.gutenberg.org/ebooks/77558>  
 
-Hecuba and Other Plays, Euripides;  
-Michael Wodhull [tr.] (English)  
-288 pages; November 26, 2025  
-PG #77336 <https://www.gutenberg.org/ebooks/77336>
+The Man Who Ate the Popomack,  
+Turner, W. J. (English)  
+103 pages; Tuesday, December 30, 2025  
+PG #77557 <https://www.gutenberg.org/ebooks/77557>  
 
-Poems: Scots and English,  
-Buchan, John (English with Scots)  
-107 pages; November 25, 2025  
-PG #77335 <https://www.gutenberg.org/ebooks/77335>
-
-El proceso,  
-Franz Kafka (Spanish)  
-385 pages; November 25, 2025  
-PG #77334 <https://www.gutenberg.org/ebooks/77334>
-
-Green Thursday: Stories,  
-Peterkin, Julia M. (English)  
-189 pages; November 25, 2025  
-PG #77332 <https://www.gutenberg.org/ebooks/77332>
-
-The way of all earth, Delano,  
-Edith Barnard (English)  
-283 pages; November 25, 2025  
-PG #77331 <https://www.gutenberg.org/ebooks/77331>
-
-La rive d'Asie,  
-Anet, Claude (French)  
-240 pages; November 24, 2025  
-PG #77330 <https://www.gutenberg.org/ebooks/77330>
-
-The Best Short Stories of 1925, and the Yearbook of the American Short Story,  
-O'Brien, Edward J. [ed.] (English)  
-520 pages; November 24, 2025  
-PG #77328 <https://www.gutenberg.org/ebooks/77328>
-
-The work of the War refugees committee,  
-Shaw, Flora L. (English)  
-43 pages; November 24, 2025  
-PG #77327 <https://www.gutenberg.org/ebooks/77327>
-
-Insomnia: Its causes and cure,  
-Sawyer, James (English)  
-66 pages; November 24, 2025  
-PG #77326 <https://www.gutenberg.org/ebooks/77326>
-
-Bernini, and other studies in the history of art,  
-Norton, Richard (English)  
-367 pages; November 24, 2025  
-PG #77325 <https://www.gutenberg.org/ebooks/77325>
-
-The Dark Year of Dundee (1867),  
-Alcock, Deborah (English)  
-350 pages; November 24, 2025  
-PG #77324 <https://www.gutenberg.org/ebooks/77324>
+Coffee merchandising,  
+Ukers, William H. (English)  
+318 pages; Saturday, December 27, 2025  
+PG #77554 <https://www.gutenberg.org/ebooks/77554>  
 
 The list of registered, operational mirrors is here:  
 >  <http://gutenberg.org/MIRRORS.ALL>
-
-## Join Distributed Proofreaders
-
-Visit [Distributed Proofreaders](https://pgdp.net) to learn how to create eBooks for Project Gutenberg. Proofreading a page a day is easy, fun, and a great way to help bring literature to the digital world. There are a variety of roles for the different steps involved in digitizing a printed book to make a Project Gutenberg eBook. Beginners are welcome, and there is an online tutorial to get started.
-
-> <https://pgdp.net>
 
 
 ## Find Project Gutenberg on social media
@@ -299,9 +347,9 @@ Mastodon New eBooks: <https://mastodon.social/@gutenberg_new>
 Bluesky: <https://bsky.app/profile/gutenberg.org>  
 Bluesky New eBooks: <https://bsky.app/profile/new.gutenberg.org>
 
-Reddit: <https://reddit.com/r/ProjectGutenberg>
+Reddit: <https://reddit.com/r/projectgutenberg>
 
-Thanks to the Project Gutenberg Social Media Team for keeping these feeds interesting!
+If you use social media, please feel invited to respond with upvotes or comments or questions. Your shares and reposts help spread awareness of Project Gutenberg’s library.
 
 ---
 


### PR DESCRIPTION
Updated the newsletter for January 2026. Lightly edited from the version that was released on the mailing list.