### PR TITLE
Reword Reading Lists intro text

### DIFF
--- a/site/ebooks/bookshelf/index.md
+++ b/site/ebooks/bookshelf/index.md
@@ -6,7 +6,9 @@ permalink: /ebooks/bookshelf/
 
 Reading Lists
 ==================================================
-Reading Lists are relatively small selections that have been hand-curated by individual volunteers. <br> <br> For the more common, large categories you may find in physical bookstores check out <a href="/ebooks/categories"> Main Categories. </a>
+Reading Lists are small selections hand-curated by our volunteers. For broader, more common categories, see <a href="/ebooks/categories"> Main Categories. </a>
+
+
 
 
 <h2> Collections </h2>


### PR DESCRIPTION
Tightens intro on the Reading Lists page. More concise. Also, it's visually nicer to have just 1 line rather than 2.