### PR TITLE
bibrec: restyle 'Other formats' disclosure

### DIFF
--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3840,7 +3840,7 @@ body.bibrec_page {
 
 .bibrec_page .other-formats-summary {
   cursor: pointer;
-  font-size: 21px;
+  font-size: 1.3125em;
   font-weight: bold;
   color: #3e444d;
   text-decoration: underline;
@@ -3857,10 +3857,10 @@ body.bibrec_page {
   display: inline-block;
   width: 0;
   height: 0;
-  border-top: 7px solid transparent;
-  border-bottom: 7px solid transparent;
-  border-left: 9px solid #427E94;
-  margin-right: 10px;
+  border-top: 0.333em solid transparent;
+  border-bottom: 0.333em solid transparent;
+  border-left: 0.429em solid #427E94;
+  margin-right: 0.476em;
   vertical-align: middle;
   transition: transform 0.15s ease;
 }
@@ -3906,7 +3906,7 @@ body.bibrec_page {
 }
 
 .bibrec_page .other-format-link {
-  font-size: 17px;
+  font-size: 1.0625em;
   color: #003366;
 }
 
@@ -3937,16 +3937,16 @@ body.bibrec_page {
 
 @media (max-width: 768px) {
   .bibrec_page .other-formats-summary {
-    font-size: 20px;
+    font-size: 1.25em;
   }
   .bibrec_page .other-format-link {
-    font-size: 16px;
+    font-size: 1em;
   }
 }
 
 @media (max-width: 400px) {
   .bibrec_page .other-formats-summary {
-    font-size: 17px;
+    font-size: 1.0625em;
   }
 }
 

--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3625,7 +3625,7 @@ body.bibrec_page {
 /* ----- Summary typography ----- */
 
 .bibrec_page .summary-text-container {
-  font-size: 18px;
+  font-size: 1.125em;
   line-height: 1.5;
   max-width: max(800px, 80%);
 }
@@ -3655,7 +3655,7 @@ body.bibrec_page {
   background-color: #c7dde3;
   color: #3e444d;
   font-weight: bold;
-  font-size: 17px;
+  font-size: 1.0625em;
   letter-spacing: 0.3px;
   text-decoration: none;
   border: none;
@@ -3725,14 +3725,14 @@ body.bibrec_page {
 }
 
 .bibrec_page .featured-format-name {
-  font-size: 18px;
+  font-size: 1.125em;
   font-weight: 600;
   text-decoration: underline;
   color: #1a1a1a;
 }
 
 .bibrec_page .featured-format-recommended {
-  font-size: 14px;
+  font-size: 0.875em;
   font-weight: 600;
   color: #2d5f2e;
   text-decoration: none;
@@ -3775,7 +3775,7 @@ body.bibrec_page {
   flex-direction: column;
   gap: 10px;
   margin-top: 20px;
-  font-size: 17px;
+  font-size: 1.0625em;
   line-height: 1.4;
   color: #444;
 }
@@ -3797,7 +3797,7 @@ body.bibrec_page {
     flex-wrap: wrap;
   }
   .bibrec_page .featured-format-tips {
-    font-size: 16px;
+    font-size: 1em;
   }
 }
 
@@ -3821,7 +3821,7 @@ body.bibrec_page {
   margin-top: 0;
   margin-bottom: 0.2em;
   color: #666;
-  font-size: 16px;
+  font-size: 1em;
 }
 
 @media (max-width: 768px) {

--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3193,7 +3193,7 @@ h1 .icon {
 
 #qr .qr-details > summary {
   cursor: pointer;
-  font-size: 16px;
+  font-size: 1em;
   color: #003366;
   list-style: none;
   user-select: none;

--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3194,7 +3194,7 @@ h1 .icon {
 #qr .qr-details > summary {
   cursor: pointer;
   font-size: 16px;
-  color: #3e444d;
+  color: #003366;
   list-style: none;
   user-select: none;
   text-decoration: underline;

--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3194,7 +3194,7 @@ h1 .icon {
 #qr .qr-details > summary {
   cursor: pointer;
   font-size: 16px;
-  color: #003366;
+  color: #3e444d;
   list-style: none;
   user-select: none;
   text-decoration: underline;
@@ -3674,7 +3674,8 @@ body.bibrec_page {
   .bibrec_page .read-online-button,
   .bibrec_page .featured-format-row,
   .bibrec_page .featured-format-actions a,
-  .bibrec_page .other-format-actions a {
+  .bibrec_page .other-format-actions a,
+  .bibrec_page .other-formats-summary::before {
     transition: none;
   }
 }
@@ -3841,8 +3842,41 @@ body.bibrec_page {
   cursor: pointer;
   font-size: 21px;
   font-weight: bold;
-  color: #333;
+  color: #3e444d;
+  text-decoration: underline;
   user-select: none;
+  list-style: none;
+}
+
+.bibrec_page .other-formats-summary::-webkit-details-marker {
+  display: none;
+}
+
+.bibrec_page .other-formats-summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-left: 9px solid #427E94;
+  margin-right: 10px;
+  vertical-align: middle;
+  transition: transform 0.15s ease;
+}
+
+.bibrec_page details[open] > .other-formats-summary::before {
+  transform: rotate(90deg);
+}
+
+.bibrec_page .other-formats-summary:hover,
+.bibrec_page .other-formats-summary:focus {
+  color: #1a1a1a;
+}
+
+.bibrec_page .other-formats-summary:hover::before,
+.bibrec_page .other-formats-summary:focus::before {
+  border-left-color: #2f6478;
 }
 
 .bibrec_page .other-formats-list {
@@ -3907,6 +3941,12 @@ body.bibrec_page {
   }
   .bibrec_page .other-format-link {
     font-size: 16px;
+  }
+}
+
+@media (max-width: 400px) {
+  .bibrec_page .other-formats-summary {
+    font-size: 17px;
   }
 }
 


### PR DESCRIPTION
Make it clearer that "Other formats & older devices" is clickable (by underlining it and better icon design).
Relatively small and subtle change, but relatively important I think. Screenshot below.

Also - "Other formats & older devices" was wrapping onto two lines on small screens. Fixed that.