### PR TITLE
Update mirroring best practices

### DIFF
--- a/site/help/mirroring.md
+++ b/site/help/mirroring.md
@@ -31,7 +31,7 @@ We offer two distinct collections:
 - the "main" collection consists of our manually curated HTML and plain text files, their zip archives, and audio files
 - the "generated" collection includes EPUB and MOBI (a.k.a., Kindle) files, generated HTML, and more automatically generated files
 
-Information about each collection size is available in the [metadata.json](//www.gutenberg.org/dirs/metadata.json) file at the base of the main collection. There are around 6 million files, over 60 languages, and dozens of different file formats. If creating a private mirror, you may opt to mirror only the zip files or to leave out the audio files, or other variations. The rsync "--exclude" option may be used for this.
+Information about each collection size is available in the [metadata.json](//www.gutenberg.org/dirs/metadata.json) file at the base of the main collection. There are around 6 million files, over 60 languages, and dozens of different file formats. If creating a private mirror, you may opt to mirror only the zip files or to leave out the audio files, or other variations. The rsync `--exclude` option may be used for this.
 
 The main collection changes daily, as new items are added or updated. The generated content may be regenerated in big batches resulting traffic spikes when refreshing the mirror.
 

--- a/site/help/mirroring.md
+++ b/site/help/mirroring.md
@@ -11,15 +11,15 @@ Mirroring How-To
 
 <div class="contents">
 <ol>
-<li><a href="#Connectivity">Connectivity</a></li>
-<li><a href="#Collections_and_Metadata">Collections and Metadata</a></li>
-<li><a href="#Software">Software</a></li>
-<li><a href="#Using_rsync">Using rsync</a>
+<li><a href="#connectivity">Connectivity</a></li>
+<li><a href="#collections-and-metadata">Collections and Metadata</a></li>
+<li><a href="#software">Software</a></li>
+<li><a href="#using-rsync">Using rsync</a>
 <ol class="inner_1">
-<li><a href="#Refreshing_the_Mirror">Refreshing the Mirror</a></li>
+<li><a href="#refreshing-the-mirror">Refreshing the Mirror</a></li>
 </ol>
 </li>
-<li><a href="#Getting_Your_Mirror_Listed">Getting Your Mirror Listed</a></li>
+<li><a href="#getting-your-mirror-listed">Getting Your Mirror Listed</a></li>
 </ol>
 </div>
 

--- a/site/help/mirroring.md
+++ b/site/help/mirroring.md
@@ -12,10 +12,11 @@ Mirroring How-To
 <div class="contents">
 <ol>
 <li><a href="#Connectivity">Connectivity</a></li>
+<li><a href="#Collections_and_Metadata">Collections and Metadata</a></li>
 <li><a href="#Software">Software</a></li>
-<li><a href="#Using_Rsync">Using Rsync</a>
-<ol class="inner_1"> 
-<li><a href="#Full_example">Full example</a></li>
+<li><a href="#Using_rsync">Using rsync</a>
+<ol class="inner_1">
+<li><a href="#Refreshing_the_Mirror">Refreshing the Mirror</a></li>
 </ol>
 </li>
 <li><a href="#Getting_Your_Mirror_Listed">Getting Your Mirror Listed</a></li>
@@ -25,67 +26,86 @@ Mirroring How-To
 ## Connectivity
 Our experience has been that a static IP address and T1 (~1.5Mb symmetric) or faster permanent network connection is minimal for a public mirror. (Of course, you can build a private mirror with a DSL or cable modem, but sharing it with the world requires a somewhat higher bandwidth.)
 
-See files "du-sk" and "ls-R" in the top-level directory for the current collection size and number of files. New eBooks are added almost every day, so it's desirable to mirror nightly. There are around 2 million files, over 60 languages, and dozens of different file formats. You may opt to mirror only the zip files or to leave out the audio files, or other variations. The rsync "--exclude" option may be used for this. 
+## Collections and Metadata
+We offer two distinct collections:
+- the "main" collection consists of our manually curated HTML and plain text files, their zip archives, and audio files
+- the "generated" collection includes EPUB and MOBI (a.k.a., Kindle) files, generated HTML, and more automatically generated files
+
+Information about each collection size is available in the [metadata.json](//www.gutenberg.org/dirs/metadata.json) file at the base of the main collection. There are around 6 million files, over 60 languages, and dozens of different file formats. If creating a private mirror, you may opt to mirror only the zip files or to leave out the audio files, or other variations. The rsync "--exclude" option may be used for this.
+
+The main collection changes daily, as new items are added or updated. The generated content may be regenerated in big batches resulting traffic spikes when refreshing the mirror.
+
+Please note that the two collections have a very different directory structure. The main collection uses a hierarchy of small directories, e.g., eBook #12345 is stored under `1/2/3/4/12345/`. The generated content uses one huge 'root' directory with a subdirectory for each book. eBook #12345 is stored in `epub/12345/`. You should configure your server to not autoindex the huge 'root' directory. There is an `index.html` file, to make it less likely for remote HTTP clients to enumerate the entire directory.
+
+There is an historical anomaly with the generated content. In the main collection, it is listed under `cache/epub`, while the catalog metadata uses `cache/generated`. If you would like to keep all of the content in one large directory tree, similar to how the main collection works, your front end Web server will need to redirect to use the same path. In other words, you will want a path from the catalog, such as `cache/generated/1001/1001.epub` to also be available as `cache/epub/1001/1001.epub`. We use a simple redirect within Apache for this (we put this in `apache.conf`, but it can be in other locations):
+```
+AllowOverride FileInfo
+RewriteEngine on
+RewriteRule ^cache/generated(/.*)?$ cache/epub$1 [L]
+```
 
 ## Software
-We recommend that you use *rsync*. The wget and cURL tools are not suitable, because they need to look at all files just to get the ones that were updated recently. Rsync is available for all Unix-like systems (including MacOS), and is part of Cygwin for Windows.
+We highly recommend that you use *rsync* to create and refresh your mirror. The wget and cURL tools are not suitable, because they need to look at all files just to get the ones that were updated recently. rsync is available for all Unix-like systems (including macOS), and is part of Cygwin for Windows.
 
-We offer two distinct rsync modules: 
-- the "main" collection, which consist of our manually curated HTML and plain text files, their zip archives and audio files and
-- the automatically generated content, including EPUB and MOBI (a.k.a., Kindle) files, generated HTML, and more automatically generated files.
-The main collection changes daily, as new items are added or updated. The generated content may be regenerated in big batches, causing rsync traffic spikes. 
+### Using rsync
+The ibiblio site is the main home of Project Gutenberg, but it is not the only server. Below are examples for an alternate server, as well as for the main ibiblio site.
 
-## Using Rsync
-The ibiblio site is the main home of Project Gutenberg, but it is not the fastest server. Below are examples for an alternate server which is faster, as well as for the main ibiblio site.
-
-To rsync the main collection: 
-<pre>
- rsync -av --del rsync.ibiblio.org::gutenberg /var/www/gutenberg
- rsync -av --del aleph.gutenberg.org::gutenberg /var/www/gutenberg
-</pre>
+To rsync the main collection:
+```
+rsync -av --del rsync.ibiblio.org::gutenberg /var/www/gutenberg
+rsync -av --del gutenberg.pglaf.org::gutenberg /var/www/gutenberg
+```
 
 The last parameter is the directory where you want the stuff placed in your drive.
 
-To rsync the generated content: 
-<pre>
- rsync -av --del rsync.ibiblio.org::gutenberg-epub /var/www/gutenberg-generated
- rsync -av --del aleph.gutenberg.org::gutenberg-epub /var/www/gutenberg-generated
-</pre>
+To rsync the generated content:
+```
+rsync -av --del rsync.ibiblio.org::gutenberg-epub /var/www/gutenberg-generated
+rsync -av --del gutenberg.pglaf.org::gutenberg-epub /var/www/gutenberg-generated
+```
 
-Please note that the two modules have a very different directory structure. The main collection uses a hierarchy of small directories, e.g., eBook #12345 is stored under 1/2/3/4/12345/. The generated content uses one huge 'root' directory with a subdirectory for each book. eBook #12345 is stored in epub/12345/. You should configure your server to not autoindex the huge 'root' directory. There is an 'index.html' file, to make it less likely for remote HTTP clients to enumerate the entire directory.
-
-You should run a daily job to check for newly updated files. Unix/Linux employs cron for this; Windows systems could use the task scheduler. We can help you with setting up the mirroring software, or any other details, if you would like.
+### Refreshing the Mirror
+You should run a daily job to check for newly updated files and refresh your mirror. Unix/Linux employs cron for this; Windows systems could use the task scheduler. We can help you with setting up the mirroring software, or any other details, if you would like.
 
 Put one or both of the aforementioned commands into a shell script and then call the shell script from your crontab.
 
-Here is a sample cron entry for a daily job, sending normal output to /dev/null (error output will be sent via email):
+Here is a full crontab example from one of our mirrors. Please do not just blindly copy it, though, since it will need adjusting for your environment (minimally, the directory path that is the destination for the files and pick another time of day to spread out the mirror load).
+```
+# Main collection
+# Note: we use '--exclude=cache' because we rsync the generated collection into a
+#       cache subdirectory in the next crontab so we don't want it deleted here.
+15  4 * * * /usr/bin/rsync -avHS --timeout 600 --delete --exclude=cache gutenberg.pglaf.org::gutenberg /data/htdocs/gutenberg
 
-<pre>
- 0 2 * * * /path/to/shell_script > /dev/null
-</pre>
-
-### Full example
-Here is a full crontab example from one of our mirrors. Please do not just blindly copy it, though, since it will need adjusting for your environment (minimally, the directory path that is the destination for the files). 
-<pre>
- 15 4 * * * /usr/bin/rsync -avHS --timeout 600 --delete --exclude 'cache/' aleph.gutenberg.org::gutenberg /data/htdocs/gutenberg > /dev/null ;
- /usr/bin/rsync -avHS --timeout 600 --delete --exclude '\*/mbt-\*' aleph.gutenberg.org::gutenberg-epub /data/htdocs/gutenberg/cache/epub
-</pre>
-
-There is an historical anomaly with the generated content. In the main collection, it is listed under "cache/epub," while the catalog metadata uses "cache/generated". If you would like to keep all of the content in one large directory tree, similar to how the main collection works, your front end Web server will need to redirect, to use the same path. In other words, you will want a path from the catalog, such as "cache/generated/1001/1001.epub" to also be available as "cache/epub/1001/1001.epub." We use a simple redirect within Apache for this (we put this in apache.conf, but it can be in other locations):
-<pre>
- AllowOverride FileInfo
- RewriteEngine on
- RewriteRule ^cache/generated(/.*)?$ cache/epub$1 [L]
-</pre>
+# Generated collection
+15 16 * * * /usr/bin/rsync -avHS --timeout 600 --delete gutenberg.pglaf.org::gutenberg-epub /data/htdocs/gutenberg/cache/epub
+```
 
 ## Getting Your Mirror Listed
-Once you have successfully installed and tested your configuration, we'll add your site to the list of mirrors, so people can find you. Contact us and we'll announce it in our next newsletters. After a month or so (to confirm stability) we'll add you to the mirror list and to the mirror selection page of each eBook. 
+If you wish to create a public mirror, you may elect to host either the main collection, the generated collection, or both. Before you start you might want to view our [mirror list](//www.gutenberg.org/MIRRORS.ALL) to check whether the geographical location of your server would be a good addition to the list.
 
-Before you start you might want to view our [mirror list](//www.gutenberg.org/MIRRORS.ALL) to check whether the geographical location of your server would be a good addition to the list.
+While you're welcome to present the public collection using any method you choose -- HTTP, FTP, rsync, TOR, BitTorrent, p2p, or others -- we ask you use rsync to create and update your copy from us.
+
+If providing public rsync access to your mirror, here is a suggested `rsyncd.conf` file:
+```
+[gutenberg]
+    comment = Project Gutenberg main collection
+    path = /data/mirrors/gutenberg
+    read only = yes
+    open noatime = true
+    refuse options = c
+    exclude = /cache/***
+
+[gutenberg-epub]
+    comment = Project Gutenberg generated collection
+    path = /data/mirrors/gutenberg/cache/epub
+    read only = yes
+    open noatime = true
+    dont compress = *
+    refuse options = c
+```
+
+Once you have successfully installed and tested your configuration, contact us and let us know. After a month or so to confirm stability and recency we'll add you to the mirror list and announce it in our next newsletter so people can find you.
 
 The book directories are the only part we offer for mirror. The Project Gutenberg catalog in XML/RDF is in the root directory of the generated content, if you would like to make your own search software. We do not package the central search software or Web pages used at www.gutenberg.org for reuse, however you may see most tools on [github](https://github.com/gutenbergtools).
 
-You may distribute our books by any means you choose: HTTP, FTP, rsync, TOR, BitTorrent, p2p or others.
-
-Thanks for your interest in helping Project Gutenberg reach more readers. 
-
+Thanks for your interest in helping Project Gutenberg reach more readers.

--- a/site/newsletter/february.md
+++ b/site/newsletter/february.md
@@ -141,7 +141,7 @@ This past week, we sent emails or letters to about 200 donors of $100 or more, w
 
 As you must know, Project Gutenberg is a dynamic, impactful organization that does amazing work sending out over a million free ebooks a day. It has a small budget (which we hope to grow!) financed mostly by small donations from over a thousand users, ranging from the 5 dollar bill we recently received in the mail from a schoolgirl in East Setauket, NY to *slightly* larger donations.
 
-We've posted our [recently-filed IRS Form 990](https://www.gutenberg.org/about/pglaf.html#tax_status) return for our fiscal year ending June 30, 2025 on the website. It shows donation income of $117,756 (not bad!) and a deficit of *-23,397* (not good). On the bright side, donations for the current fiscal year are up by ~30% over last year (very good!). The closure of our Salt Lake City office will save us a lot of money. (sad, but necessary.)
+We've posted our [recently-filed IRS Form 990](https://www.gutenberg.org/about/pglaf.html#tax-status) return for our fiscal year ending June 30, 2025 on the website. It shows donation income of $117,756 (not bad!) and a deficit of *-23,397* (not good). On the bright side, donations for the current fiscal year are up by ~30% over last year (very good!). The closure of our Salt Lake City office will save us a lot of money. (sad, but necessary.)
 
 If you want to send us paper mail, the address is:
 > Project Gutenberg Literary Archive Foundation <br> 41 Watchung Plaza #516<br> Montclair NJ 07042


### PR DESCRIPTION
This revamps and clarifies our mirror content and best practices for using our (PGLAF & ibiblio) mirrors and creating a public one. The content has been restructured a bit to discuss the collections separately from the rsync details they were embedded in.