### PR TITLE
Bibrec adjustments

### DIFF
--- a/gutenberg/gutenberg-globals.css
+++ b/gutenberg/gutenberg-globals.css
@@ -3194,7 +3194,7 @@ h1 .icon {
 #qr .qr-details > summary {
   cursor: pointer;
   font-size: 1em;
-  color: #003366;
+  color: #3e444d;
   list-style: none;
   user-select: none;
   text-decoration: underline;
@@ -3673,6 +3673,7 @@ body.bibrec_page {
 @media (prefers-reduced-motion: reduce) {
   .bibrec_page .read-online-button,
   .bibrec_page .featured-format-row,
+  .bibrec_page .other-format-row,
   .bibrec_page .featured-format-actions a,
   .bibrec_page .other-format-actions a,
   .bibrec_page .other-formats-summary::before {
@@ -3788,6 +3789,13 @@ body.bibrec_page {
   text-decoration: underline;
 }
 
+/* Always show these reading-help links in the muted visited-grey, regardless
+   of whether they've actually been visited. */
+.bibrec_page .featured-format-tips a:link,
+.bibrec_page .featured-format-tips a:visited {
+  color: #3e444d;
+}
+
 @media (max-width: 768px) {
   .bibrec_page .featured-format-link {
     flex-wrap: wrap;
@@ -3884,31 +3892,52 @@ body.bibrec_page {
 
 .bibrec_page .other-format-row {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 12px;
   background: #f8f8f8;
   border-radius: 4px;
   border-left: 3px solid #ccc;
+  transition: background-color 0.2s ease;
+}
+
+.bibrec_page .other-format-row:hover {
+  background: #ececec;
 }
 
 .bibrec_page .other-format-info {
+  flex: 1 1 max-content;
   display: flex;
-  align-items: baseline;
+  align-items: stretch;
   gap: 6px;
   flex-wrap: wrap;
 }
 
+/* The link fills the whole left region (like the featured EPUB3 row), so the
+   entire area left of the cloud icons is a click target, not just the text. */
 .bibrec_page .other-format-link {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 12px;
   font-size: 1em;
   color: #003366;
 }
 
+/* Suppress the global link hover background so the row's own darken shows
+   through instead of a blue fill — matches the featured EPUB3 link. */
+.bibrec_page a.other-format-link:hover,
+.bibrec_page a.other-format-link:focus {
+  background: transparent;
+}
+
 .bibrec_page .other-format-actions {
   display: flex;
+  align-items: center;
   gap: 8px;
+  padding: 8px 12px;
+  background: #f8f8f8;
+  border-radius: 0 4px 4px 0;
 }
 
 .bibrec_page .other-format-size,


### PR DESCRIPTION
- Made the "Other formats & older devices" download options work more like EPUB3 i.e. darken background onhover and make the entire row up to the cloud icons clickable to initiate download
- Adjusted the color of the qr-code link and of the links in the "Download" card to be the color that usually only gets activated after a link has been clicked. it's nicer. (I thought it was already like that since I myself had clicked all links)

