### PR TITLE
Change top ten process to produce HTML instead of PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ to_delete
 BACKUP
 .aider*
 .DS_Store
-
+tmp

--- a/catalog/admin/make-topten.php
+++ b/catalog/admin/make-topten.php
@@ -24,8 +24,6 @@ $config->page_encoding = "UTF-8";
 
 function mk_header($title)
 {
-    include_once("pg.phh");
-
     $menu = <<<'MENU'
 <header>
     <input type="radio" name="toggle" id="search-toggle" style="display: none" >

--- a/catalog/admin/make-topten.php
+++ b/catalog/admin/make-topten.php
@@ -20,17 +20,197 @@ if ($docroot) {
     $config->documentroot = $docroot;
 }
 
+$config->page_encoding = "UTF-8";
+
 function mk_header($title)
 {
+    include_once("pg.phh");
+
+    $menu = <<<'MENU'
+<header>
+    <input type="radio" name="toggle" id="search-toggle" style="display: none" >
+    <input type="radio" name="toggle" id="search-close" style="display: none" >
+    <input type="checkbox" id="about-toggle" style="display: none" >
+    <div class="logo-container">
+        <a id="main_logo" href="/" class="no-hover">
+            <img src="/gutenberg/pg-logo-new.jpg" alt="Project Gutenberg" draggable="false" >
+        </a>
+    </div>
+
+    <div class="top-header">
+        <form
+            class="search-form"
+            method="get"
+            action="/ebooks/search/"
+            accept-charset="utf-8"
+        >
+            <label
+                for="search-toggle"
+                class="search-icon-btn"
+                aria-label="Open Search"
+            >
+                <svg
+                    class="search-icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    width="1em"
+                    height="1em"
+                >
+                    <path
+                        d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 0 0 1.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 0 0-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 0 0 5.34-1.48l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                    <path d="M0 0h24v24H0z" fill="none" />
+                </svg>
+            </label>
+            <label for="search-close" class="search-close-btn" aria-label="Close Search">X</label>
+            <input
+                type="text"
+                class="search-input"
+                name="query"
+                placeholder="Quick search"
+                aria-label="Search books"
+            >
+            <button type="submit" class="search-button">Go!</button>
+        </form>
+
+        <div class="donate-container">
+            <form
+                class="donatelink"
+                action="https://www.paypal.com/cgi-bin/webscr"
+                method="post"
+                target="new"
+            >
+                <input type="hidden" name="cmd" value="_s-xclick" >
+                <input
+                    type="hidden"
+                    name="hosted_button_id"
+                    value="XKAL6BZL3YPSN"
+                >
+                <input
+                    class="donbtn"
+                    type="image"
+                    src="/pics/en_US.gif"
+                    name="submit"
+                    alt="Donate via PayPal"
+                >
+            </form>
+            <a href="/donate/" class="donate-link"> Donate </a>
+        </div>
+    </div>
+
+    <div class="lower-header" role="navigation">
+        <div class="dropdown" tabindex="0">
+            <label for="about-toggle" class="dropdown-button" aria-haspopup="true">About<span aria-hidden="true" class="dropdown-icon">▼</span></label>
+            <div class="dropdown-content">
+                <a href="/about/">About Project Gutenberg </a>
+                <a href="/help/reading_options.html">Reading Options & Kindle</a>
+                <a href="/about/contact_information.html">Contact Us</a>
+                <a href="/about/background/">History &amp; Philosophy</a>
+                <a href="/help/">Help Pages</a>
+                <a href="/ebooks/offline_catalogs.html">Offline Catalogs</a>
+                <a href="/donate/">Donate</a>
+            </div>
+        </div>
+
+        <div class="main-links">
+            <a href="/browse/scores/top" class="link-freq-downloaded"
+                >Frequently Downloaded</a
+            >
+            <a href="/ebooks/categories" class="link-main-categories"
+                >Main Categories</a
+            >
+            <a href="/ebooks/bookshelf/" class="link-reading-lists"
+                >Reading Lists</a
+            >
+            <a href="/ebooks/" class="link-advanced-search">Search Options</a>
+        </div>
+    </div>
+
+    <div class="tertiary-header" >
+        <a href="/browse/scores/top" class="tertiary-link link-freq-downloaded"
+            >Frequently Downloaded</a
+        >
+        <a href="/ebooks/categories" class="tertiary-link link-main-categories"
+            >Main Categories</a
+        >
+    </div>
+</header>
+
+MENU;
+
     $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-    return "<!doctype html>\n"
-            . "<html lang=\"en\">\n"
+    return "<!DOCTYPE html>\n"
+            . "<html class=\"client-nojs\" lang=\"en-US\" dir=\"ltr\" data-lt-installed=\"true\">\n"
             . "<head>\n"
             . "  <meta charset=\"UTF-8\">\n"
-            . "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-            . "  <title>$safeTitle</title>\n"
+            . "  <title>$safeTitle | Project Gutenberg</title>\n"
+            . "\n"
+            . " <link rel=\"stylesheet\" href=\"/gutenberg/gutenberg-globals.css\">\n"
+            . "\n"
+            . "\n"
+            . " <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+            . " <meta name=\"keywords\" content=\"books, ebooks, free, kindle, android, iphone, ipad\">\n"
+            . " <meta name=\"google-site-verification\" content=\"wucOEvSnj5kP3Ts_36OfP64laakK-1mVTg-ptrGC9io\">\n"
+            . " <meta name=\"alexaVerifyID\" content=\"4WNaCljsE-A82vP_ih2H_UqXZvM\">\n"
+            . " \n"
+            . " <link rel=\"copyright\" href=\"https://www.gnu.org/copyleft/fdl.html\">\n"
+            . " <link rel=\"icon\" type=\"image/png\" href=\"/gutenberg/favicon.ico\" sizes=\"16x16\" >\n"
+            . " \n"
+            . " <meta property=\"og:title\"        content=\"Project Gutenberg\" >\n"
+            . " <meta property=\"og:type\"         content=\"website\" >\n"
+            . " <meta property=\"og:url\"          content=\"https://www.gutenberg.org/\" >\n"
+            . " <meta property=\"og:description\"  content=\"Project Gutenberg is a library of free eBooks.\" >\n"
+            . " <meta property=\"fb:admins\"       content=\"615269807\" >\n"
+            . " <meta property=\"fb:app_id\"       content=\"115319388529183\" >\n"
+            . " <meta property=\"og:site_name\"    content=\"Project Gutenberg\" >\n"
+            . " <meta property=\"og:image\"        content=\"https://www.gutenberg.org/gutenberg/pg-logo-144x144.png\" >\n"
             . "</head>\n"
-            . "<body>\n\n";
+            . "<body>\n"
+            . "<div class=\"container\"><!-- start body -->\n"
+            . $menu
+            . "<div class=\"page_content\"><!-- start content -->\n";
+}
+
+function mk_footer($handle)
+{
+    $footer = <<<'HTML'
+    </div><!--content ending-->
+    </div><!-- body ending -->
+     <div class="footer" role="contentinfo"><!-- start footer -->
+
+    <ul>
+        <li>
+            <a href="/about/">About Project Gutenberg</a>
+        </li>
+        <li>
+            <a href="/policy/privacy_policy.html">Privacy policy</a>
+        </li>
+        <li>
+            <a href="/policy/permission.html" title="Permissions, Licensing and other Common Requests">Permissions</a>
+        </li>
+        <li>
+            <a href="/policy/terms_of_use.html">Terms of Use</a>
+        </li>
+        <li>
+            <a href="/a11y/">Accessibility</a>
+        </li>
+        <li>
+            <a href="/about/contact_information.html" title="How to contact Project Gutenberg">Contact Us</a>
+        </li>
+        <li><a href="/help/" title="Help, How-To, Procedures, Guidance and Information">Help</a></li>
+    </ul>
+
+    <a href="https://www.ibiblio.org/" title="Project Gutenberg is hosted by ibiblio">
+     <img src="/gutenberg/ibiblio-logo.png" alt="ibiblio" width="110" height="32">
+    </a>
+
+     </div><!-- footer ending-->
+ </body>
+</html>
+HTML;
+
+    fwrite($handle, $footer);
 }
 
 $dir = "browse";
@@ -182,8 +362,6 @@ foreach ($langs as $l) {
     }
 
     if ($hd = fopen($file = "$config->documentroot/$dir_scores/top$filesuffix.html", "w")) {
-        echo("writing $file ... downloads ...\n");
-
         $d1 = downloads("$langwhere date >= current_date - interval '1 days'");
         $d7 = downloads("$langwhere date >= current_date - interval '7 days'");
         $d30 = downloads("$langwhere date >= current_date - interval '30 days'");
@@ -191,10 +369,11 @@ foreach ($langs as $l) {
         fputs($hd, mk_header("Top $titlesuffix"));
 
         $s = <<< EOF
+
             <h1>Frequently Viewed or Downloaded</h1>
 
             <details>
-            <summary style="cursor: pointer">Click here to see download statistics</summary>
+            <summary style="cursor: pointer" save_image_to_download="true">Click here to see download statistics</summary>
 
             <p>Calculated from the number of times each eBook gets
             downloaded. (Multiple downloads from the same Internet
@@ -228,14 +407,10 @@ foreach ($langs as $l) {
 
         // Yesterday
 
-        echo(" yesterday ... books ...");
-
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"books-last1\">Top $num EBooks yesterday</h2>\n\n");
 
         fputs($hd, topbooks($num, "$langwhere date >= current_date - interval '1 days'"));
-
-        echo(" authors ...");
 
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"authors-last1\">Top $num Authors yesterday</h2>\n\n");
@@ -244,14 +419,10 @@ foreach ($langs as $l) {
 
         // Last 7 days
 
-        echo(" last 7 days ... books ...");
-
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"books-last7\">Top $num EBooks last 7 days</h2>\n\n");
 
         fputs($hd, topbooks($num, "$langwhere date >= current_date - interval '7 days'"));
-
-        echo(" authors ...");
 
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"authors-last7\">Top $num Authors last 7 days</h2>\n\n");
@@ -260,14 +431,10 @@ foreach ($langs as $l) {
 
         // Last 30 days
 
-        echo(" last 30 days ... books ...");
-
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"books-last30\">Top $num EBooks last 30 days</h2>\n\n");
 
         fputs($hd, topbooks($num, "$langwhere date >= current_date - interval '30 days'"));
-
-        echo(" authors ...");
 
         fputs($hd, $links);
         fputs($hd, "<h2 id=\"authors-last30\">Top $num Authors last 30 days</h2>\n\n");
@@ -276,7 +443,7 @@ foreach ($langs as $l) {
 
         fputs($hd, $links);
 
-        fputs($hd, "</body>\n</html>\n");
+        mk_footer($hd);
         fclose($hd);
 
         echo(" done.\n");

--- a/catalog/admin/make-topten.php
+++ b/catalog/admin/make-topten.php
@@ -22,12 +22,15 @@ if ($docroot) {
 
 function mk_header($title)
 {
-    global $config;
-    return "<?php
-  include (\"pgbrowse.phh\");
-  \$config->page_encoding = \"UTF-8\";
-  pageheader (\"$title\");
-?>\n\n";
+    $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+    return "<!doctype html>\n"
+            . "<html lang=\"en\">\n"
+            . "<head>\n"
+            . "  <meta charset=\"UTF-8\">\n"
+            . "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+            . "  <title>$safeTitle</title>\n"
+            . "</head>\n"
+            . "<body>\n\n";
 }
 
 $dir = "browse";
@@ -178,7 +181,7 @@ foreach ($langs as $l) {
         $langwhere = "fk_langs = '$lang' AND ";
     }
 
-    if ($hd = fopen($file = "$config->documentroot/$dir_scores/top$filesuffix.php", "w")) {
+    if ($hd = fopen($file = "$config->documentroot/$dir_scores/top$filesuffix.html", "w")) {
         echo("writing $file ... downloads ...\n");
 
         $d1 = downloads("$langwhere date >= current_date - interval '1 days'");
@@ -273,7 +276,7 @@ foreach ($langs as $l) {
 
         fputs($hd, $links);
 
-        fputs($hd, "<?php pagefooter (); ?>\n");
+        fputs($hd, "</body>\n</html>\n");
         fclose($hd);
 
         echo(" done.\n");

--- a/catalog/admin/make-topten.py
+++ b/catalog/admin/make-topten.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Generate top download score pages as static HTML.
+
+Python port of catalog/admin/make-topten.php.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover
+    psycopg = None
+
+try:
+    import psycopg2  # type: ignore
+except ImportError:  # pragma: no cover
+    psycopg2 = None
+
+DISQUALIFIED_BOOKS = (0, 6550, 6557, 9280, 9695, 9714)
+DISQUALIFIED_AUTHORS = (49, 116, 216)
+
+
+@dataclass(frozen=True)
+class Settings:
+    dsn: str
+    document_root: Path
+    etext_base: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate top score HTML pages from scores.book_downloads"
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.getenv("PGCAT_DSN", ""),
+        help=(
+            "PostgreSQL DSN. Defaults to PGCAT_DSN; if not set, "
+            "constructed from PG* environment variables."
+        ),
+    )
+    parser.add_argument(
+        "--document-root",
+        default=os.getenv("PUBLIC", ""),
+        help="Document root directory. Defaults to PUBLIC environment variable.",
+    )
+    parser.add_argument(
+        "--etext-base",
+        default=os.getenv("ETEXT_BASE", "/ebooks"),
+        help="Base URL for ebook links.",
+    )
+    return parser.parse_args()
+
+
+def build_dsn(explicit_dsn: str) -> str:
+    if explicit_dsn:
+        return explicit_dsn
+
+    # Allow using standard PostgreSQL environment variables.
+    pg_keys = {
+        "host": "PGHOST",
+        "port": "PGPORT",
+        "dbname": "PGDATABASE",
+        "user": "PGUSER",
+        "password": "PGPASSWORD",
+    }
+    pairs = []
+    for dsn_key, env_key in pg_keys.items():
+        value = os.getenv(env_key)
+        if value:
+            pairs.append(f"{dsn_key}={value}")
+
+    if not pairs:
+        raise ValueError(
+            "No database settings found. Set --dsn / PGCAT_DSN or standard PG* environment variables."
+        )
+
+    return " ".join(pairs)
+
+
+def normalize_title(raw_title: str | None, fk_book: int, max_len: int = 100) -> str:
+    if not raw_title:
+        return f"EBook #{fk_book}"
+    title = re.sub(r"\s+", " ", raw_title).strip()
+    if len(title) <= max_len:
+        return title
+    return title[: max_len - 3].rstrip() + "..."
+
+
+def find_browse_page(author: str) -> str:
+    # Legacy PHP logic is in pgcat.phh, which is not present in this workspace.
+    # This fallback keeps links deterministic by bucketing on first alnum char.
+    author = (author or "").strip().lower()
+    for ch in author:
+        if ch.isalpha() or ch.isdigit():
+            return ch
+    return "other"
+
+
+def mk_header(title: str) -> str:
+    safe_title = html.escape(title, quote=True)
+    return (
+        "<!doctype html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "  <meta charset=\"UTF-8\">\n"
+        "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+        f"  <title>{safe_title}</title>\n"
+        "</head>\n"
+        "<body>\n\n"
+    )
+
+
+def downloads(cur, lang: str, span: str) -> int:
+    if lang:
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(downloads), 0) AS downloads
+            FROM dl
+            WHERE fk_langs = %s AND date >= current_date - interval %s
+            """,
+            (lang, span),
+        )
+    else:
+        cur.execute(
+            """
+            SELECT COALESCE(SUM(downloads), 0) AS downloads
+            FROM dl
+            WHERE date >= current_date - interval %s
+            """,
+            (span,),
+        )
+    row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+def topbooks(cur, num: int, lang: str, span: str, etext_base: str) -> str:
+    where_sql = "date >= current_date - interval %s"
+    params: list[object] = [span]
+    if lang:
+        where_sql = "fk_langs = %s AND " + where_sql
+        params.insert(0, lang)
+
+    cur.execute(
+        f"""
+        SELECT dl.fk_books, SUM(dl.downloads) AS downloads, b.title
+        FROM dl
+        LEFT JOIN books b ON b.pk = dl.fk_books
+        WHERE {where_sql}
+        GROUP BY dl.fk_books, b.title
+        ORDER BY downloads DESC
+        LIMIT %s
+        """,
+        params + [num],
+    )
+
+    out = ["<ol>"]
+    etext_prefix = etext_base.rstrip("/")
+    for fk_books, dl_count, title in cur.fetchall():
+        friendly = html.escape(normalize_title(title, fk_books, 100), quote=False)
+        out.append(
+            f'<li><a href="{etext_prefix}/{fk_books}">{friendly} ({dl_count})</a></li>'
+        )
+    out.append("</ol>")
+    return "\n".join(out) + "\n"
+
+
+def topauthors(cur, num: int, lang: str, span: str) -> str:
+    where_sql = "date >= current_date - interval %s"
+    params: list[object] = [span]
+    if lang:
+        where_sql = "fk_langs = %s AND " + where_sql
+        params.insert(0, lang)
+
+    cur.execute(
+        f"""
+        SELECT author, fk_authors, SUM(dl.downloads) AS downloads
+        FROM authors, mn_books_authors, dl
+        WHERE {where_sql}
+          AND authors.pk = mn_books_authors.fk_authors
+          AND mn_books_authors.fk_books = dl.fk_books
+          AND fk_authors NOT IN %s
+        GROUP BY author, fk_authors
+        ORDER BY downloads DESC
+        LIMIT %s
+        """,
+        params + [DISQUALIFIED_AUTHORS, num],
+    )
+
+    out = ["<ol>"]
+    for author, fk_authors, dl_count in cur.fetchall():
+        href = find_browse_page(author) + f"#a{fk_authors}"
+        safe_author = html.escape(author, quote=False)
+        out.append(f'<li><a href="/browse/authors/{href}">{safe_author} ({dl_count})</a></li>')
+    out.append("</ol>")
+    return "\n".join(out) + "\n"
+
+
+def get_connection(dsn: str):
+    if psycopg is not None:
+        return psycopg.connect(dsn)
+    if psycopg2 is not None:
+        return psycopg2.connect(dsn)
+    raise RuntimeError("Neither psycopg (v3) nor psycopg2 is installed.")
+
+
+def ensure_dirs(document_root: Path) -> Path:
+    scores_dir = document_root / "browse" / "scores"
+    scores_dir.mkdir(parents=True, exist_ok=True)
+    return scores_dir
+
+
+def iter_lang_limits(cur) -> Iterable[tuple[str, int]]:
+    # Top 100 and top 1000 across all languages.
+    yield ("", 100)
+    yield ("", 1000)
+
+    cur.execute(
+        """
+        SELECT fk_langs, COUNT(fk_langs) AS cnt
+        FROM mn_books_langs
+        GROUP BY fk_langs
+        ORDER BY cnt DESC
+        """
+    )
+    for fk_langs, _cnt in cur.fetchall():
+        yield (fk_langs, 100)
+
+
+def main() -> int:
+    args = parse_args()
+
+    document_root_raw = args.document_root.strip()
+    if not document_root_raw:
+        print("ERROR: --document-root or PUBLIC must be set", file=sys.stderr)
+        return 2
+
+    settings = Settings(
+        dsn=build_dsn(args.dsn),
+        document_root=Path(document_root_raw),
+        etext_base=args.etext_base,
+    )
+
+    scores_dir = ensure_dirs(settings.document_root)
+
+    with get_connection(settings.dsn) as conn:
+        conn.autocommit = False
+        with conn.cursor() as cur:
+            print("creating temp table ...", end="", flush=True)
+            cur.execute(
+                """
+                CREATE TEMP TABLE dl AS
+                SELECT scores.book_downloads.fk_books,
+                       scores.book_downloads.date,
+                       scores.book_downloads.downloads,
+                       fk_langs
+                FROM scores.book_downloads, mn_books_langs
+                WHERE scores.book_downloads.fk_books = mn_books_langs.fk_books
+                  AND scores.book_downloads.fk_books NOT IN %s
+                """,
+                (DISQUALIFIED_BOOKS,),
+            )
+            print(" done.")
+
+            cur.execute("SELECT MAX(date) AS latest, MIN(date) AS earliest FROM scores.book_downloads")
+            latest, _earliest = cur.fetchone()
+            latest_str = latest.strftime("%Y-%m-%d")
+
+            links = (
+                "  <style>\n"
+                "    #books-downloads-nav { display: inline-block; overflow: auto; border: solid 1px #eee; padding: 1em; background: #fafafa;}\n"
+                "  </style>\n"
+                "  <div id=\"books-downloads-nav\">\n"
+                "    <b>Top 100 EBooks:</b> <a href=\"#books-last1\">Yesterday</a> - <a href=\"#books-last7\">7&nbsp;days</a> - <a href=\"#books-last30\">30&nbsp;days</a><br>\n"
+                "    <b>Top 100 Authors:</b> <a href=\"#authors-last1\">Yesterday</a> - <a href=\"#authors-last7\">7&nbsp;days</a> - <a href=\"#authors-last30\">30&nbsp;days</a>\n"
+                "  </div>\n"
+            )
+
+            for lang, num in iter_lang_limits(cur):
+                file_suffix = ""
+                title_suffix = str(num)
+                if num != 100:
+                    file_suffix += str(num)
+                if lang:
+                    file_suffix += f"-{lang}"
+                    title_suffix += f" ({lang})"
+
+                out_file = scores_dir / f"top{file_suffix}.html"
+                print(f"writing {out_file} ... downloads ...")
+
+                d1 = downloads(cur, lang, "1 days")
+                d7 = downloads(cur, lang, "7 days")
+                d30 = downloads(cur, lang, "30 days")
+
+                with out_file.open("w", encoding="utf-8") as hd:
+                    hd.write(mk_header(f"Top {title_suffix}"))
+                    hd.write(
+                        f"""
+<h1>Frequently Viewed or Downloaded</h1>
+
+<details>
+<summary style=\"cursor: pointer\">Click here to see download statistics</summary>
+
+<p>Calculated from the number of times each eBook gets
+ downloaded. (Multiple downloads from the same Internet
+ address on the same day count as one download. Addresses
+ that download more than 100 eBooks in a day are considered
+ robots and are not counted.)</p>
+
+<table id=\"books-downloads-table\">
+  <caption>Downloaded Books</caption>
+  <tr><th>{latest_str}</th><td class=\"right\">{d1}</td></tr>
+  <tr><th>last 7 days</th><td class=\"right\">{d7}</td></tr>
+  <tr><th>last 30 days</th><td class=\"right\">{d30}</td></tr>
+</table>
+
+<p>Visualizations and graphs are available as
+<a href=\"/about/pretty-pictures.html\">pretty pictures</a>.</p>
+
+</details>
+"""
+                    )
+
+                    print(" yesterday ... books ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="books-last1">Top {num} EBooks yesterday</h2>\n\n')
+                    hd.write(topbooks(cur, num, lang, "1 days", settings.etext_base))
+
+                    print(" authors ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="authors-last1">Top {num} Authors yesterday</h2>\n\n')
+                    hd.write(topauthors(cur, num, lang, "1 days"))
+
+                    print(" last 7 days ... books ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="books-last7">Top {num} EBooks last 7 days</h2>\n\n')
+                    hd.write(topbooks(cur, num, lang, "7 days", settings.etext_base))
+
+                    print(" authors ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="authors-last7">Top {num} Authors last 7 days</h2>\n\n')
+                    hd.write(topauthors(cur, num, lang, "7 days"))
+
+                    print(" last 30 days ... books ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="books-last30">Top {num} EBooks last 30 days</h2>\n\n')
+                    hd.write(topbooks(cur, num, lang, "30 days", settings.etext_base))
+
+                    print(" authors ...", end="", flush=True)
+                    hd.write(links)
+                    hd.write(f'<h2 id="authors-last30">Top {num} Authors last 30 days</h2>\n\n')
+                    hd.write(topauthors(cur, num, lang, "30 days"))
+
+                    hd.write(links)
+                    hd.write("</body>\n</html>\n")
+
+                print(" done.")
+
+            conn.rollback()  # temp table lifecycle only
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
See pg-static issue \#17 [static files should not be served by php](https://github.com/gutenbergtools/pg-static/issues/17).
This PR just converts make-topten.php, need to determine what else could be done., and whether it addresses the security issues.